### PR TITLE
Update rl.py for trado

### DIFF
--- a/rl.py
+++ b/rl.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
             train(i, target = None)
 
         if i % config.experiment.eval_every == 0:
-            if model_base == "sdar":
+            if model_base in ["sdar", "trado"]:
                 remasking_strategy_list = config.evaluation.remasking_strategy
                 top_k_list = config.evaluation.top_k
                 block_size = config.evaluation.block_size


### PR DESCRIPTION
trado配置和sdar基本一致，block_size config里面是int而不是list，之前的在评估的时候跑到这里会执行else然后报错。