### PR TITLE
Set keep_trailing_newline=True to preserve the trailing newline when …

### DIFF
--- a/data/preprocess_sft.ipynb
+++ b/data/preprocess_sft.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "\n",
     "def get_prompt(data_i):\n",
-    "    return Template(system_prompts).render(problem = data_i[\"prompt\"])\n",
+    "    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i[\"prompt\"])\n",
     "processed_data = []\n",
     "for i in range(len(data)):\n",
     "    processed_data.append(\n",

--- a/sample/dream_rl_rollout.py
+++ b/sample/dream_rl_rollout.py
@@ -367,7 +367,7 @@ def random_select(data_list, random_k):
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 
 

--- a/sample/dream_sample.py
+++ b/sample/dream_sample.py
@@ -360,7 +360,7 @@ def random_select(data_list, random_k):
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 
 

--- a/sample/llada_rl_rollout.py
+++ b/sample/llada_rl_rollout.py
@@ -201,7 +201,7 @@ def random_select(data_list, random_k):
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 
 def extract_final_boxed_answer(s: str):

--- a/sample/llada_sample.py
+++ b/sample/llada_sample.py
@@ -201,7 +201,7 @@ def random_select(data_list, random_k):
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 
 def extract_final_boxed_answer(s: str):

--- a/sample/sdar_rl_rollout.py
+++ b/sample/sdar_rl_rollout.py
@@ -39,7 +39,7 @@ def get_config():
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 def extract_final_boxed_answer(s: str):
     tag = r'\boxed{'

--- a/sample/sdar_sample.py
+++ b/sample/sdar_sample.py
@@ -37,7 +37,7 @@ def get_config():
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 def extract_final_boxed_answer(s: str):
     tag = r'\boxed{'

--- a/sample/trado_rl_rollout.py
+++ b/sample/trado_rl_rollout.py
@@ -39,7 +39,7 @@ def get_config():
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 def extract_final_boxed_answer(s: str):
     tag = r'\boxed{'

--- a/sample/trado_sample.py
+++ b/sample/trado_sample.py
@@ -37,7 +37,7 @@ def get_config():
 
 # obtain prompt
 def get_prompt(data_i):
-    return Template(system_prompts).render(problem = data_i["question"])
+    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
 
 def extract_final_boxed_answer(s: str):
     tag = r'\boxed{'


### PR DESCRIPTION
### Set keep_trailing_newline=True to preserve the trailing newline when rendering prompt templates

I noticed that the prompt Template of the paper contains a line break at the end, 
<img width="695" height="446" alt="Clipboard_Screenshot_1762746054" src="https://github.com/user-attachments/assets/dc1e1372-56ae-4515-897a-946a0bd3f662" />
but the actual inference code will remove the line break by default when using the Jinja Template:
```python
# obtain prompt
def get_prompt(data_i):
    return Template(system_prompts).render(problem = data_i["question"])
```
 This can make a difference in the reproducibility of the experiment.
So I set `keep_trailing_newline=True` in the code to prevent this problem:
```python
# obtain prompt
def get_prompt(data_i):
    return Template(system_prompts, keep_trailing_newline=True).render(problem = data_i["question"])
```

Here's my experimental results on the MATH500 dataset (using TraDo-8B-Instruct) :
| Whether to remove the newline character | ACC |
|-----|-----|
| No | 75.46666666666667 |
| Yes | 74.86666666667 |

The experimental results with end-of-line breaks (75.46...) are very close to the reported value (75.5) ! I hope this PR can help others.